### PR TITLE
chore: scaffold monorepo with Next.js and NestJS skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.next
+dist
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Dabang Sales Dashboard
+
+Monorepo for a sample sales dashboard built with Next.js and NestJS.
+
+## Apps
+
+- **web** – Next.js frontend.
+- **api** – NestJS backend.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev:web     # start Next.js
+pnpm dev:api     # start NestJS
+```
+
+## Environment
+
+Create `.env` from `.env.example`.
+
+## Testing
+
+```
+pnpm test
+```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node src/main.ts",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { DashboardModule } from './dashboard/dashboard.module';
+
+@Module({
+  imports: [DashboardModule],
+})
+export class AppModule {}

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { MetricsResponse } from './dto/metrics-response.dto';
+
+@ApiTags('dashboard')
+@Controller('api/dashboard')
+export class DashboardController {
+  constructor(private readonly svc: DashboardService) {}
+
+  @Get('metrics')
+  @ApiOkResponse({ type: MetricsResponse })
+  getMetrics(): MetricsResponse {
+    return this.svc.getMetrics();
+  }
+}

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { MetricTile } from './dto/metric-tile.dto';
+import { MetricsResponse } from './dto/metrics-response.dto';
+
+@Injectable()
+export class DashboardService {
+  getMetrics(): MetricsResponse {
+    const tiles: MetricTile[] = [
+      { label: 'Total Sales', value: 1000, deltaPct: 6, icon: 'payments', currency: 'USD' },
+      { label: 'Total Order', value: 300, deltaPct: 5, icon: 'receipt' },
+      { label: 'Product Sold', value: 5, deltaPct: 12, icon: 'sell' },
+      { label: 'New Customers', value: 8, deltaPct: 0.5, icon: 'person_add' },
+    ];
+    return { tiles };
+  }
+}

--- a/apps/api/src/dashboard/dto/metric-tile.dto.ts
+++ b/apps/api/src/dashboard/dto/metric-tile.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MetricTile {
+  @ApiProperty()
+  label!: string;
+
+  @ApiProperty()
+  value!: number;
+
+  @ApiProperty()
+  deltaPct!: number;
+
+  @ApiProperty()
+  icon!: string;
+
+  @ApiProperty({ required: false })
+  currency?: 'USD';
+}

--- a/apps/api/src/dashboard/dto/metrics-response.dto.ts
+++ b/apps/api/src/dashboard/dto/metrics-response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MetricTile } from './metric-tile.dto';
+
+export class MetricsResponse {
+  @ApiProperty({ type: [MetricTile] })
+  tiles!: MetricTile[];
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,13 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const config = new DocumentBuilder().setTitle('Dashboard').setVersion('1.0').build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
+
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { MetricTile } from '../types/dashboard';
+
+async function fetchMetrics(): Promise<MetricTile[]> {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+  const res = await fetch(`${base}/api/dashboard/metrics`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Failed to fetch metrics');
+  const data = await res.json();
+  return data.tiles as MetricTile[];
+}
+
+export default async function Page() {
+  const tiles = await fetchMetrics();
+  return (
+    <main>
+      <h1>Dashboard</h1>
+      <pre>{JSON.stringify(tiles, null, 2)}</pre>
+    </main>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/types/dashboard.ts
+++ b/apps/web/types/dashboard.ts
@@ -1,0 +1,7 @@
+export type MetricTile = {
+  label: string;
+  value: number;
+  deltaPct: number;
+  icon: string;
+  currency?: 'USD';
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dabang-dashboard",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev:web": "pnpm --filter web dev",
+    "dev:api": "pnpm --filter api start:dev",
+    "build": "pnpm -r build",
+    "test": "echo \"no tests\""
+  }
+}

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "sourceMap": true
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@dabang/tsconfig",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- set up pnpm workspace with web (Next.js) and api (NestJS)
- stub dashboard API returning metric tiles
- render metrics on Next.js dashboard page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd1804515c833383ceb17004a85196